### PR TITLE
Fix README heading formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Pour créer une extension Chrome, suivez ces étapes :
 
 ### License
 
-- [Custom License](./LICENSE.txt)## Nouveaux ajouts
+- [Custom License](./LICENSE.txt)
 
 ## Nouveaux ajouts
 


### PR DESCRIPTION
## Summary

- Fix the README license link line so it no longer swallows the `Nouveaux ajouts` heading.
- Leave a single rendered `## Nouveaux ajouts` heading after the license link.

Closes #18.

## Validation

- `git diff --check`
- Verified the README now has `Custom License` on its own line followed by one `## Nouveaux ajouts` heading.
- Claude Code CLI reviewed the README-only diff as PASS.